### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/gitlablogo/GitlabLogoProperty/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/gitlablogo/GitlabLogoProperty/global.jelly
@@ -25,8 +25,11 @@
     <script>
       var GitlabLogoProperty = {
         clearCache: function(){
-          new Ajax.Request("${rootURL}/descriptor/org.jenkinsci.plugins.gitlablogo.GitlabLogoProperty/clearCache", {
-            onSuccess: function(rsp) {
+          fetch("${rootURL}/descriptor/org.jenkinsci.plugins.gitlablogo.GitlabLogoProperty/clearCache", {
+            method: "post",
+            headers: crumb.wrap({}),
+          }).then((rsp) => {
+            if (rsp.ok) {
               alert("Clear cache done");
             }
           });


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this I clicked the clear cache button and stepped over the changed lines in a debugger successfully. I verified the new code behaved the same way as the old.